### PR TITLE
fix: Ensure proper evaluation of generator expression in assert statement

### DIFF
--- a/lib/lab_channel.py
+++ b/lib/lab_channel.py
@@ -184,7 +184,7 @@ class Channel:
         :return: None
         """
         # destination_set needs to contain string identifiers
-        assert (type(k) is str for k in destination_set), 'type error'
+        assert all(type(k) is str for k in destination_set), 'type error'
 
         # lookup member id by pid and validate it
         caller: str = self.os_members[os.getpid()]


### PR DESCRIPTION
#### Description
This pull request addresses an issue where the `assert` statement incorrectly passed due to the use of a generator expression without proper evaluation. The fix involves wrapping the generator expression in `all()`, ensuring that it evaluates correctly and the assertion functions as intended.

#### Impact
The correction ensures that the `assert` statement properly verifies that all elements in `destination_set` are strings, preventing potential bugs related to type errors in this set.